### PR TITLE
FIX: reversed long-lat url string

### DIFF
--- a/Assets/JS/main.js
+++ b/Assets/JS/main.js
@@ -126,7 +126,7 @@ function setWeather(weatherTime, longlat) {
     const apikey = getAPIKey();
 
     //fetch written by AI
-    fetch(`${url}?latitude=${longlat.long}&longitude=${longlat.lat}`, {
+    fetch(`${url}?latitude=${longlat.lat}&longitude=${longlat.long}`, {
         method: 'GET',
         headers: {
             'accept': 'application/json',
@@ -333,7 +333,7 @@ document.addEventListener("DOMContentLoaded", function () {
     }
 });
 
-updateWeatherHour("Burnley");
+updateWeatherHour("Bristol");
 
 
 // Toggle between GPS and Location Search


### PR DESCRIPTION
URL for API was using long for lat, and lat for long. Fixed