### PR TITLE
FIX: HTTP API changed to HTTPS

### DIFF
--- a/Assets/JS/main.js
+++ b/Assets/JS/main.js
@@ -7,10 +7,10 @@ function getMetofficeAPIKey() {
         `eyJ4NXQjUzI1NiI6Ik5XVTVZakUxTkRjeVl6a3hZbUl4TkdSaFpqSmpOV1l6T1dGaE9XWXpNMk0yTWpRek5USm1OVEE0TXpOaU9EaG1NVFJqWVdNellXUm1ZalUyTTJJeVpBPT0iLCJraWQiOiJnYXRld2F5X2NlcnRpZmljYXRlX2FsaWFzIiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ==.eyJzdWIiOiJtb2d0aGVtb3NxdWl0b0BnbWFpbC5jb21AY2FyYm9uLnN1cGVyIiwiYXBwbGljYXRpb24iOnsib3duZXIiOiJtb2d0aGVtb3NxdWl0b0BnbWFpbC5jb20iLCJ0aWVyUXVvdGFUeXBlIjpudWxsLCJ0aWVyIjoiVW5saW1pdGVkIiwibmFtZSI6InNpdGVfc3BlY2lmaWMtMDViNTQ1ODAtYWYwZS00ZmJjLWI1ZjMtMmE5ZmViOWVlYjdjIiwiaWQiOjkzMzEsInV1aWQiOiI1NDgxMTc1Mi01NjlkLTQ4MWMtODU2Ny1iYTVhN2RlZGIzMzIifSwiaXNzIjoiaHR0cHM6XC9cL2FwaS1tYW5hZ2VyLmFwaS1tYW5hZ2VtZW50Lm1ldG9mZmljZS5jbG91ZDo0NDNcL29hdXRoMlwvdG9rZW4iLCJ0aWVySW5mbyI6eyJ3ZGhfc2l0ZV9zcGVjaWZpY19mcmVlIjp7InRpZXJRdW90YVR5cGUiOiJyZXF1ZXN0Q291bnQiLCJncmFwaFFMTWF4Q29tcGxleGl0eSI6MCwiZ3JhcGhRTE1heERlcHRoIjowLCJzdG9wT25RdW90YVJlYWNoIjp0cnVlLCJzcGlrZUFycmVzdExpbWl0IjowLCJzcGlrZUFycmVzdFVuaXQiOiJzZWMifX0sImtleXR5cGUiOiJQUk9EVUNUSU9OIiwic3Vic2NyaWJlZEFQSXMiOlt7InN1YnNjcmliZXJUZW5hbnREb21haW4iOiJjYXJib24uc3VwZXIiLCJuYW1lIjoiU2l0ZVNwZWNpZmljRm9yZWNhc3QiLCJjb250ZXh0IjoiXC9zaXRlc3BlY2lmaWNcL3YwIiwicHVibGlzaGVyIjoiSmFndWFyX0NJIiwidmVyc2lvbiI6InYwIiwic3Vic2NyaXB0aW9uVGllciI6IndkaF9zaXRlX3NwZWNpZmljX2ZyZWUifV0sInRva2VuX3R5cGUiOiJhcGlLZXkiLCJpYXQiOjE3Mzg2NjU1MTksImp0aSI6IjlmMDQ2MWJiLWFmODctNDc3MC1hYzRhLTMxN2RiODE1NjQxYyJ9.AEFlnjZrvfSlDBzGF90mZb5hH9yXQ-RLkNKBzOOJOs-tKJctS05iLIgL0SjlohsskiYhLphVG4tZ4qgqnR2X97mGjXjtzYALoaDQYI1IBXBN9MEAIdoqhPAMghzlkgOSzjyc7_NpB8pALsqOzHVdediOr4TVmQv04lEfwpPs8Lp2ALByGadWDzSBBzN-qLktCjRS0H-oHDCC2qHoKTF-p3svvyvah9hCWTG-HaWK1JcsEpAPIqD-uu2KtOxkSUq097WPKpNno1dybsISx6uBZSVeP7ejP0sH16omqk03fPHAgNv9aE5buhmTkCQDO46X-VBk_zmF9BNtqTbNUkes3g==`,
         `eyJ4NXQjUzI1NiI6Ik5XVTVZakUxTkRjeVl6a3hZbUl4TkdSaFpqSmpOV1l6T1dGaE9XWXpNMk0yTWpRek5USm1OVEE0TXpOaU9EaG1NVFJqWVdNellXUm1ZalUyTTJJeVpBPT0iLCJraWQiOiJnYXRld2F5X2NlcnRpZmljYXRlX2FsaWFzIiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ==.eyJzdWIiOiJ6NGQxNTkyZ0BzdHVkZW50cy5jb2RlaW5zdGl0dXRlLm5ldEBjYXJib24uc3VwZXIiLCJhcHBsaWNhdGlvbiI6eyJvd25lciI6Ino0ZDE1OTJnQHN0dWRlbnRzLmNvZGVpbnN0aXR1dGUubmV0IiwidGllclF1b3RhVHlwZSI6bnVsbCwidGllciI6IlVubGltaXRlZCIsIm5hbWUiOiJzaXRlX3NwZWNpZmljLTlmYTI0MWZhLTM0NDgtNGZlZi1iNDNjLWEwNWIwMDlhNWUwMiIsImlkIjo5MzY1LCJ1dWlkIjoiNjU4MzNkNGEtNTk3Yi00OWE1LTk5M2YtOWE1YTg0MGVkMDIzIn0sImlzcyI6Imh0dHBzOlwvXC9hcGktbWFuYWdlci5hcGktbWFuYWdlbWVudC5tZXRvZmZpY2UuY2xvdWQ6NDQzXC9vYXV0aDJcL3Rva2VuIiwidGllckluZm8iOnsid2RoX3NpdGVfc3BlY2lmaWNfZnJlZSI6eyJ0aWVyUXVvdGFUeXBlIjoicmVxdWVzdENvdW50IiwiZ3JhcGhRTE1heENvbXBsZXhpdHkiOjAsImdyYXBoUUxNYXhEZXB0aCI6MCwic3RvcE9uUXVvdGFSZWFjaCI6dHJ1ZSwic3Bpa2VBcnJlc3RMaW1pdCI6MCwic3Bpa2VBcnJlc3RVbml0Ijoic2VjIn19LCJrZXl0eXBlIjoiUFJPRFVDVElPTiIsInN1YnNjcmliZWRBUElzIjpbeyJzdWJzY3JpYmVyVGVuYW50RG9tYWluIjoiY2FyYm9uLnN1cGVyIiwibmFtZSI6IlNpdGVTcGVjaWZpY0ZvcmVjYXN0IiwiY29udGV4dCI6Ilwvc2l0ZXNwZWNpZmljXC92MCIsInB1Ymxpc2hlciI6IkphZ3Vhcl9DSSIsInZlcnNpb24iOiJ2MCIsInN1YnNjcmlwdGlvblRpZXIiOiJ3ZGhfc2l0ZV9zcGVjaWZpY19mcmVlIn1dLCJ0b2tlbl90eXBlIjoiYXBpS2V5IiwiaWF0IjoxNzM4NzU0MTIxLCJqdGkiOiJiZDc0NTNhNC1kYWFiLTQxM2EtOWVkMi1mOWZhMzc2MDBlZmIifQ==.VtadWMvaTxSBp55FKJDaX56Qz9jU9AofwaBA0-SfY7Z0mSqi1wNOonBGDH4y2ZucJMjp_kgwZEMR19P60Su8EaaSWbQque-3pARI2fgkrFcF99LJRj0OqwgU2B4G-U1xuEkqWIh7f0ZlFB-G1hiPg9-zzbdTvWLxyZkZy-77iPSFxbgn4aTNG8hKatdpXLRnVm9b___M1PpkXn25MDxey8_VKb4sTtXQ2VKv14DjNENRvr2_3HFape_qeTXFrSrzBT_N-pY2ecB7TQ_giDSdLZV0KePo_XNhWYD7KvKMCciRPri1UtEhnlXOPTqkcgw_pbXDF0gvSLBvDcZZkWTVLw==`,
         `eyJ4NXQjUzI1NiI6Ik5XVTVZakUxTkRjeVl6a3hZbUl4TkdSaFpqSmpOV1l6T1dGaE9XWXpNMk0yTWpRek5USm1OVEE0TXpOaU9EaG1NVFJqWVdNellXUm1ZalUyTTJJeVpBPT0iLCJraWQiOiJnYXRld2F5X2NlcnRpZmljYXRlX2FsaWFzIiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ==.eyJzdWIiOiJyYWxmY3Jhd3NoYXc3NEBnbWFpbC5jb21AY2FyYm9uLnN1cGVyIiwiYXBwbGljYXRpb24iOnsib3duZXIiOiJyYWxmY3Jhd3NoYXc3NEBnbWFpbC5jb20iLCJ0aWVyUXVvdGFUeXBlIjpudWxsLCJ0aWVyIjoiVW5saW1pdGVkIiwibmFtZSI6InNpdGVfc3BlY2lmaWMtNjQyYWQ1NGEtODk3Yy00NzAwLThlMWUtZmVhNDkwMjk2ODhkIiwiaWQiOjkzOTIsInV1aWQiOiJiOTAyZTE0OC1hNzg3LTQ2YmQtOTYwMC1iYWRiNGQxN2M2MWYifSwiaXNzIjoiaHR0cHM6XC9cL2FwaS1tYW5hZ2VyLmFwaS1tYW5hZ2VtZW50Lm1ldG9mZmljZS5jbG91ZDo0NDNcL29hdXRoMlwvdG9rZW4iLCJ0aWVySW5mbyI6eyJ3ZGhfc2l0ZV9zcGVjaWZpY19mcmVlIjp7InRpZXJRdW90YVR5cGUiOiJyZXF1ZXN0Q291bnQiLCJncmFwaFFMTWF4Q29tcGxleGl0eSI6MCwiZ3JhcGhRTE1heERlcHRoIjowLCJzdG9wT25RdW90YVJlYWNoIjp0cnVlLCJzcGlrZUFycmVzdExpbWl0IjowLCJzcGlrZUFycmVzdFVuaXQiOiJzZWMifX0sImtleXR5cGUiOiJQUk9EVUNUSU9OIiwic3Vic2NyaWJlZEFQSXMiOlt7InN1YnNjcmliZXJUZW5hbnREb21haW4iOiJjYXJib24uc3VwZXIiLCJuYW1lIjoiU2l0ZVNwZWNpZmljRm9yZWNhc3QiLCJjb250ZXh0IjoiXC9zaXRlc3BlY2lmaWNcL3YwIiwicHVibGlzaGVyIjoiSmFndWFyX0NJIiwidmVyc2lvbiI6InYwIiwic3Vic2NyaXB0aW9uVGllciI6IndkaF9zaXRlX3NwZWNpZmljX2ZyZWUifV0sInRva2VuX3R5cGUiOiJhcGlLZXkiLCJpYXQiOjE3Mzg4MzUwMDAsImp0aSI6IjVkNGY3ODIyLTdiM2YtNDM1ZS1iYmNmLWZhOTQ2MTg3MTNmNyJ9.CYQI5OUl1nwBwioROfmmlAM0r0swciDa9SrSzPQZq9I-gSCXSlBXmqJr__DLHxNWOx-xWJpkwnssMSUq1L_L6L4n24KxfVl53MYws9X3o_yM9C3Ll9GvIMxSJgXD4PqQubxZreh6oJMGTnSV9hFWWsxPw7siWbqQgIkFFfkJpNvOnTc2unFMf5lJCTrFplqD6azOGWoq5dmwRS9tUc-waXbMN9ZfPsemhwK5Ok080w1Bl6DvsvnmaAc0GTQcmZg9-gP3nnBig6jmTgs4lP424A-GBb3i0XzUtxl_a_aWWpp53FNnLP1Nny_RA-Itv4YMdUGpVQCkoPKkhAWeeU71Og==`,
-        ];
-       const randomValue = values[Math.floor(Math.random() * values.length)];
-       return randomValue;
-}   
+    ];
+    const randomValue = values[Math.floor(Math.random() * values.length)];
+    return randomValue;
+}
 
 /**
  * API Key
@@ -19,7 +19,7 @@ function getMetofficeAPIKey() {
 function getGeoapifyAPIKey() {
     const apiKey = `ea97085f2c31444792c7ddcf6ff4017c`;
     return apiKey;
-}   
+}
 
 /**
  * Geolocation API
@@ -57,7 +57,7 @@ function usePosition(position) {
     getTownName(latitude, longitude);
 
     //WARNING/IMPORTANT: limited API uses, un-comment when ready to deploy/use
-    updateWeatherHour("London", { "long": longitude, "lat": latitude });
+    //updateWeatherHour("London", { "long": longitude, "lat": latitude });
 }
 
 /**
@@ -96,7 +96,7 @@ function showError(error) {
 
 /**
  * Geoapify API
- * reverse geocoding to get the town name from the latitude and longitude
+ * reverse geocoding to get the town name from the geolocation data latitude and longitude
  */
 function getTownName(lat, long) {
     const url = `https://api.geoapify.com/v1/geocode/reverse`;
@@ -112,7 +112,7 @@ function getTownName(lat, long) {
         .then(response => response.json())
         .then(data => {
             // Process town name here
-            if(data.features[0].properties.city == undefined){
+            if (data.features[0].properties.city == undefined) {
                 setGPSLocation("Couldn't find\nlocation name");
             } else {
                 setGPSLocation(data.features[0].properties.city);
@@ -224,29 +224,48 @@ function parseSearchInput(userInput) {
  * and passes this through to the next fetch for weather data
  */
 function getLongLat(placeName, weatherTime) {
-    const url = `https:api.postcodes.io/places?query=${placeName}`;
+    // remove any user whitespace
+    const trimPlaceName = (placeName.trim()).toLowerCase();
+    const apiKey = getGeoapifyAPIKey();
+    const url = `https://api.geoapify.com/v1/geocode/search?city=${trimPlaceName}&filter=countrycode:auto&apiKey=${apiKey}`;
     let long = 0;
     let lat = 0;
     console.log('Fetching URL:', url);
-    fetch(url)
+    fetch(url, {
+        method: 'GET',
+        headers: {
+            'accept': 'application/json',
+        }
+    })
         .then(response => response.json())
         .then(data => {
-            let foundTown = false;
-            for (let i = 0; i < data.result.length; i++) {
-                if (data.result[i].local_type == "Town" || data.result[i].local_type == "City") {
-                    foundTown = true;
-                    console.log(`Place: ${data.result[i].name_1}, Longitude: ${data.result[i].longitude}, Latitude: ${data.result[i].latitude}`);
-                    long = parseFloat(data.result[i].longitude).toFixed(4);
-                    lat = parseFloat(data.result[i].latitude).toFixed(4);
-                    let longLatObj = { "long": long, "lat": lat };
+            console.log(data);
+            let foundLocation = false;
+            for (let i = 0; i < data.features.length; i++) {
+                // gets the result type property (which can be town, city, suburb, postcode (for village), etc)
+                // checks if an object property exists for the result type value.
+                // if it does, we can then compare the property value to the place name. (e.g. data.features[i].properties.town: "keynsham")
+                const resultType = data.features[i].properties.resultType;
+                let resultValue = "";
+                if (Object.hasOwn(data.features[i].properties, resultType)) {
+                    resultValue = data.features[i].properties[resultType];
+                }
+
+                if ((resultValue.toLowerCase()) === trimPlaceName) {
+                    foundLocation = true;
+                    console.log(`Place: ${data.features[i].properties.formatted}, Latitude: ${data.features[i].properties.lat}, Longitude: ${data.features[i].properties.lon}`);
+                    lat = parseFloat(data.features[i].properties.lat).toFixed(4);
+                    long = parseFloat(data.features[i].properties.lon).toFixed(4);
+                    
+                    let longLatObj = { "lat": lat, "long": long };
 
                     setWeather(weatherTime, longLatObj);
 
                     break;
                 }
             }
-            if (!foundTown) {
-                console.log("User entered an invalid town: " + placeName);
+            if (!foundLocation) {
+                console.log("User entered an invalid location: " + placeName);
                 topTextAreaError("Invalid Location Name.\n\nPlease try another.");
             }
         })
@@ -603,7 +622,9 @@ document.getElementById('toggleButton').addEventListener('click', function () {
         searchbar.style.display = 'flex';
         gpsLocation.style.display = 'none';
         // hide error message header, if it was displayed
-        searchError.style.display = 'none';
+        if (searchError !== null) {
+            searchError.style.display = 'none';
+        }
     } else {
         searchbar.style.display = 'none';
         gpsLocation.style.display = 'flex';

--- a/Assets/JS/main.js
+++ b/Assets/JS/main.js
@@ -9,7 +9,6 @@ function getMetofficeAPIKey() {
         `eyJ4NXQjUzI1NiI6Ik5XVTVZakUxTkRjeVl6a3hZbUl4TkdSaFpqSmpOV1l6T1dGaE9XWXpNMk0yTWpRek5USm1OVEE0TXpOaU9EaG1NVFJqWVdNellXUm1ZalUyTTJJeVpBPT0iLCJraWQiOiJnYXRld2F5X2NlcnRpZmljYXRlX2FsaWFzIiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ==.eyJzdWIiOiJyYWxmY3Jhd3NoYXc3NEBnbWFpbC5jb21AY2FyYm9uLnN1cGVyIiwiYXBwbGljYXRpb24iOnsib3duZXIiOiJyYWxmY3Jhd3NoYXc3NEBnbWFpbC5jb20iLCJ0aWVyUXVvdGFUeXBlIjpudWxsLCJ0aWVyIjoiVW5saW1pdGVkIiwibmFtZSI6InNpdGVfc3BlY2lmaWMtNjQyYWQ1NGEtODk3Yy00NzAwLThlMWUtZmVhNDkwMjk2ODhkIiwiaWQiOjkzOTIsInV1aWQiOiJiOTAyZTE0OC1hNzg3LTQ2YmQtOTYwMC1iYWRiNGQxN2M2MWYifSwiaXNzIjoiaHR0cHM6XC9cL2FwaS1tYW5hZ2VyLmFwaS1tYW5hZ2VtZW50Lm1ldG9mZmljZS5jbG91ZDo0NDNcL29hdXRoMlwvdG9rZW4iLCJ0aWVySW5mbyI6eyJ3ZGhfc2l0ZV9zcGVjaWZpY19mcmVlIjp7InRpZXJRdW90YVR5cGUiOiJyZXF1ZXN0Q291bnQiLCJncmFwaFFMTWF4Q29tcGxleGl0eSI6MCwiZ3JhcGhRTE1heERlcHRoIjowLCJzdG9wT25RdW90YVJlYWNoIjp0cnVlLCJzcGlrZUFycmVzdExpbWl0IjowLCJzcGlrZUFycmVzdFVuaXQiOiJzZWMifX0sImtleXR5cGUiOiJQUk9EVUNUSU9OIiwic3Vic2NyaWJlZEFQSXMiOlt7InN1YnNjcmliZXJUZW5hbnREb21haW4iOiJjYXJib24uc3VwZXIiLCJuYW1lIjoiU2l0ZVNwZWNpZmljRm9yZWNhc3QiLCJjb250ZXh0IjoiXC9zaXRlc3BlY2lmaWNcL3YwIiwicHVibGlzaGVyIjoiSmFndWFyX0NJIiwidmVyc2lvbiI6InYwIiwic3Vic2NyaXB0aW9uVGllciI6IndkaF9zaXRlX3NwZWNpZmljX2ZyZWUifV0sInRva2VuX3R5cGUiOiJhcGlLZXkiLCJpYXQiOjE3Mzg4MzUwMDAsImp0aSI6IjVkNGY3ODIyLTdiM2YtNDM1ZS1iYmNmLWZhOTQ2MTg3MTNmNyJ9.CYQI5OUl1nwBwioROfmmlAM0r0swciDa9SrSzPQZq9I-gSCXSlBXmqJr__DLHxNWOx-xWJpkwnssMSUq1L_L6L4n24KxfVl53MYws9X3o_yM9C3Ll9GvIMxSJgXD4PqQubxZreh6oJMGTnSV9hFWWsxPw7siWbqQgIkFFfkJpNvOnTc2unFMf5lJCTrFplqD6azOGWoq5dmwRS9tUc-waXbMN9ZfPsemhwK5Ok080w1Bl6DvsvnmaAc0GTQcmZg9-gP3nnBig6jmTgs4lP424A-GBb3i0XzUtxl_a_aWWpp53FNnLP1Nny_RA-Itv4YMdUGpVQCkoPKkhAWeeU71Og==`,
         ];
        const randomValue = values[Math.floor(Math.random() * values.length)];
-       console.log(randomValue);
        return randomValue;
 }   
 
@@ -55,7 +54,6 @@ function usePosition(position) {
     // show button to toggle between search and GPS, now that gps api has succeeded
     toggleSearchGPSButton();
 
-    console.log("Latitude: " + latitude + " Longitude: " + longitude);
     getTownName(latitude, longitude);
 
     //WARNING/IMPORTANT: limited API uses, un-comment when ready to deploy/use
@@ -114,7 +112,6 @@ function getTownName(lat, long) {
         .then(response => response.json())
         .then(data => {
             // Process town name here
-            console.log(data);
             if(data.features[0].properties.city == undefined){
                 setGPSLocation("Couldn't find\nlocation name");
             } else {
@@ -243,7 +240,6 @@ function getLongLat(placeName, weatherTime) {
                     lat = parseFloat(data.result[i].latitude).toFixed(4);
                     let longLatObj = { "long": long, "lat": lat };
 
-                    console.log(longLatObj);
                     setWeather(weatherTime, longLatObj);
 
                     break;
@@ -278,7 +274,6 @@ function setWeather(weatherTime, longlat) {
     })
         .then(response => response.json())
         .then(data => {
-            console.log(data);
             // Process the weather data here
             if (weatherTime === "hourly") {
                 const currentWeatherHour = getOneWeatherHour(getCurrentHourISO(), getAllWeatherTimes(data));
@@ -451,7 +446,6 @@ function setFiveDayWeatherDescriptionAndIcon(weatherDays) {
  * for that weather code (a lookup table)
  */
 function getWeatherDescriptionAndIcon(weatherCode) {
-    console.log("weatherCode" + weatherCode);
     const weatherMap = {
         0: { topDescription: "Clear night", icon: "Assets/Images/clear_moon_night.png", bottomDescription: "Great starwatching weather!" },
         1: { topDescription: "Sunny", icon: "Assets/Images/sunny.png", bottomDescription: "Sunshine and smiles!" },

--- a/Assets/JS/main.js
+++ b/Assets/JS/main.js
@@ -2,7 +2,7 @@
  * API Key
  * for the Met Office API
  */
-function getAPIKey() {
+function getMetofficeAPIKey() {
     let values = [
         `eyJ4NXQjUzI1NiI6Ik5XVTVZakUxTkRjeVl6a3hZbUl4TkdSaFpqSmpOV1l6T1dGaE9XWXpNMk0yTWpRek5USm1OVEE0TXpOaU9EaG1NVFJqWVdNellXUm1ZalUyTTJJeVpBPT0iLCJraWQiOiJnYXRld2F5X2NlcnRpZmljYXRlX2FsaWFzIiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ==.eyJzdWIiOiJtb2d0aGVtb3NxdWl0b0BnbWFpbC5jb21AY2FyYm9uLnN1cGVyIiwiYXBwbGljYXRpb24iOnsib3duZXIiOiJtb2d0aGVtb3NxdWl0b0BnbWFpbC5jb20iLCJ0aWVyUXVvdGFUeXBlIjpudWxsLCJ0aWVyIjoiVW5saW1pdGVkIiwibmFtZSI6InNpdGVfc3BlY2lmaWMtMDViNTQ1ODAtYWYwZS00ZmJjLWI1ZjMtMmE5ZmViOWVlYjdjIiwiaWQiOjkzMzEsInV1aWQiOiI1NDgxMTc1Mi01NjlkLTQ4MWMtODU2Ny1iYTVhN2RlZGIzMzIifSwiaXNzIjoiaHR0cHM6XC9cL2FwaS1tYW5hZ2VyLmFwaS1tYW5hZ2VtZW50Lm1ldG9mZmljZS5jbG91ZDo0NDNcL29hdXRoMlwvdG9rZW4iLCJ0aWVySW5mbyI6eyJ3ZGhfc2l0ZV9zcGVjaWZpY19mcmVlIjp7InRpZXJRdW90YVR5cGUiOiJyZXF1ZXN0Q291bnQiLCJncmFwaFFMTWF4Q29tcGxleGl0eSI6MCwiZ3JhcGhRTE1heERlcHRoIjowLCJzdG9wT25RdW90YVJlYWNoIjp0cnVlLCJzcGlrZUFycmVzdExpbWl0IjowLCJzcGlrZUFycmVzdFVuaXQiOiJzZWMifX0sImtleXR5cGUiOiJQUk9EVUNUSU9OIiwic3Vic2NyaWJlZEFQSXMiOlt7InN1YnNjcmliZXJUZW5hbnREb21haW4iOiJjYXJib24uc3VwZXIiLCJuYW1lIjoiU2l0ZVNwZWNpZmljRm9yZWNhc3QiLCJjb250ZXh0IjoiXC9zaXRlc3BlY2lmaWNcL3YwIiwicHVibGlzaGVyIjoiSmFndWFyX0NJIiwidmVyc2lvbiI6InYwIiwic3Vic2NyaXB0aW9uVGllciI6IndkaF9zaXRlX3NwZWNpZmljX2ZyZWUifV0sInRva2VuX3R5cGUiOiJhcGlLZXkiLCJpYXQiOjE3Mzg2NjU1MTksImp0aSI6IjlmMDQ2MWJiLWFmODctNDc3MC1hYzRhLTMxN2RiODE1NjQxYyJ9.AEFlnjZrvfSlDBzGF90mZb5hH9yXQ-RLkNKBzOOJOs-tKJctS05iLIgL0SjlohsskiYhLphVG4tZ4qgqnR2X97mGjXjtzYALoaDQYI1IBXBN9MEAIdoqhPAMghzlkgOSzjyc7_NpB8pALsqOzHVdediOr4TVmQv04lEfwpPs8Lp2ALByGadWDzSBBzN-qLktCjRS0H-oHDCC2qHoKTF-p3svvyvah9hCWTG-HaWK1JcsEpAPIqD-uu2KtOxkSUq097WPKpNno1dybsISx6uBZSVeP7ejP0sH16omqk03fPHAgNv9aE5buhmTkCQDO46X-VBk_zmF9BNtqTbNUkes3g==`,
         `eyJ4NXQjUzI1NiI6Ik5XVTVZakUxTkRjeVl6a3hZbUl4TkdSaFpqSmpOV1l6T1dGaE9XWXpNMk0yTWpRek5USm1OVEE0TXpOaU9EaG1NVFJqWVdNellXUm1ZalUyTTJJeVpBPT0iLCJraWQiOiJnYXRld2F5X2NlcnRpZmljYXRlX2FsaWFzIiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ==.eyJzdWIiOiJ6NGQxNTkyZ0BzdHVkZW50cy5jb2RlaW5zdGl0dXRlLm5ldEBjYXJib24uc3VwZXIiLCJhcHBsaWNhdGlvbiI6eyJvd25lciI6Ino0ZDE1OTJnQHN0dWRlbnRzLmNvZGVpbnN0aXR1dGUubmV0IiwidGllclF1b3RhVHlwZSI6bnVsbCwidGllciI6IlVubGltaXRlZCIsIm5hbWUiOiJzaXRlX3NwZWNpZmljLTlmYTI0MWZhLTM0NDgtNGZlZi1iNDNjLWEwNWIwMDlhNWUwMiIsImlkIjo5MzY1LCJ1dWlkIjoiNjU4MzNkNGEtNTk3Yi00OWE1LTk5M2YtOWE1YTg0MGVkMDIzIn0sImlzcyI6Imh0dHBzOlwvXC9hcGktbWFuYWdlci5hcGktbWFuYWdlbWVudC5tZXRvZmZpY2UuY2xvdWQ6NDQzXC9vYXV0aDJcL3Rva2VuIiwidGllckluZm8iOnsid2RoX3NpdGVfc3BlY2lmaWNfZnJlZSI6eyJ0aWVyUXVvdGFUeXBlIjoicmVxdWVzdENvdW50IiwiZ3JhcGhRTE1heENvbXBsZXhpdHkiOjAsImdyYXBoUUxNYXhEZXB0aCI6MCwic3RvcE9uUXVvdGFSZWFjaCI6dHJ1ZSwic3Bpa2VBcnJlc3RMaW1pdCI6MCwic3Bpa2VBcnJlc3RVbml0Ijoic2VjIn19LCJrZXl0eXBlIjoiUFJPRFVDVElPTiIsInN1YnNjcmliZWRBUElzIjpbeyJzdWJzY3JpYmVyVGVuYW50RG9tYWluIjoiY2FyYm9uLnN1cGVyIiwibmFtZSI6IlNpdGVTcGVjaWZpY0ZvcmVjYXN0IiwiY29udGV4dCI6Ilwvc2l0ZXNwZWNpZmljXC92MCIsInB1Ymxpc2hlciI6IkphZ3Vhcl9DSSIsInZlcnNpb24iOiJ2MCIsInN1YnNjcmlwdGlvblRpZXIiOiJ3ZGhfc2l0ZV9zcGVjaWZpY19mcmVlIn1dLCJ0b2tlbl90eXBlIjoiYXBpS2V5IiwiaWF0IjoxNzM4NzU0MTIxLCJqdGkiOiJiZDc0NTNhNC1kYWFiLTQxM2EtOWVkMi1mOWZhMzc2MDBlZmIifQ==.VtadWMvaTxSBp55FKJDaX56Qz9jU9AofwaBA0-SfY7Z0mSqi1wNOonBGDH4y2ZucJMjp_kgwZEMR19P60Su8EaaSWbQque-3pARI2fgkrFcF99LJRj0OqwgU2B4G-U1xuEkqWIh7f0ZlFB-G1hiPg9-zzbdTvWLxyZkZy-77iPSFxbgn4aTNG8hKatdpXLRnVm9b___M1PpkXn25MDxey8_VKb4sTtXQ2VKv14DjNENRvr2_3HFape_qeTXFrSrzBT_N-pY2ecB7TQ_giDSdLZV0KePo_XNhWYD7KvKMCciRPri1UtEhnlXOPTqkcgw_pbXDF0gvSLBvDcZZkWTVLw==`,
@@ -11,6 +11,15 @@ function getAPIKey() {
        const randomValue = values[Math.floor(Math.random() * values.length)];
        console.log(randomValue);
        return randomValue;
+}   
+
+/**
+ * API Key
+ * for the Geoapify API
+ */
+function getGeoapifyAPIKey() {
+    const apiKey = `ea97085f2c31444792c7ddcf6ff4017c`;
+    return apiKey;
 }   
 
 /**
@@ -88,15 +97,15 @@ function showError(error) {
 }
 
 /**
- * Geonames API
+ * Geoapify API
  * reverse geocoding to get the town name from the latitude and longitude
  */
 function getTownName(lat, long) {
-    const url = `http://api.geonames.org/findNearbyPlaceName`;
-    const username = `moglin`;
+    const url = `https://api.geoapify.com/v1/geocode/reverse`;
+    const apiKey = getGeoapifyAPIKey();
 
     //fetch written by AI
-    fetch(`${url}?lat=${lat}&lng=${long}&username=${username}`, {
+    fetch(`${url}?lat=${lat}&lon=${long}&apiKey=${apiKey}`, {
         method: 'GET',
         headers: {
             'accept': 'application/json',
@@ -105,7 +114,12 @@ function getTownName(lat, long) {
         .then(response => response.json())
         .then(data => {
             // Process town name here
-            setGPSLocation(data.geonames[0].name);
+            console.log(data);
+            if(data.features[0].properties.city == undefined){
+                setGPSLocation("Couldn't find\nlocation name");
+            } else {
+                setGPSLocation(data.features[0].properties.city);
+            }
         })
         .catch(error => {
             console.error('Error fetching town name:', error);
@@ -252,7 +266,7 @@ function getLongLat(placeName, weatherTime) {
  */
 function setWeather(weatherTime, longlat) {
     const url = `https://data.hub.api.metoffice.gov.uk/sitespecific/v0/point/${weatherTime}`;
-    const apikey = getAPIKey();
+    const apikey = getMetofficeAPIKey();
 
     //fetch written by AI
     fetch(`${url}?latitude=${longlat.lat}&longitude=${longlat.long}`, {

--- a/Assets/JS/main.js
+++ b/Assets/JS/main.js
@@ -57,7 +57,7 @@ function usePosition(position) {
     getTownName(latitude, longitude);
 
     //WARNING/IMPORTANT: limited API uses, un-comment when ready to deploy/use
-    //updateWeatherHour("London", { "long": longitude, "lat": latitude });
+    updateWeatherHour("London", { "long": longitude, "lat": latitude });
 }
 
 /**
@@ -245,9 +245,18 @@ function getLongLat(placeName, weatherTime) {
                 // gets the result type property (which can be town, city, suburb, postcode (for village), etc)
                 // checks if an object property exists for the result type value.
                 // if it does, we can then compare the property value to the place name. (e.g. data.features[i].properties.town: "keynsham")
-                const resultType = data.features[i].properties.resultType;
+                const resultType = data.features[i].properties.result_type;
                 let resultValue = "";
-                if (Object.hasOwn(data.features[i].properties, resultType)) {
+
+                // If statement here does specific logic for postcode, as it doesn't store the
+                // location name, but city often does.
+
+                // TODO: Ultimately, we need another box for the user to select a county
+                // or even a map to select a location, as we can't rely on the first result
+                // being the one the user wants.
+                if (resultType === "postcode") {
+                    resultValue = data.features[i].properties.city;
+                } else if (Object.hasOwn(data.features[i].properties, resultType)) {
                     resultValue = data.features[i].properties[resultType];
                 }
 
@@ -271,6 +280,7 @@ function getLongLat(placeName, weatherTime) {
         })
         .catch(error => {
             console.error('Error:', error);
+            topTextAreaError("Search error.\n\nPlease try another.");
         });
 }
 


### PR DESCRIPTION
getLongLat for town name search, and getTownName reverse geolocation for town name on geolocation home screen.

changed HTTP API's for these two functions to a HTTPS API.

Needs testing on deployment.


Furthermore, the town search is now international, but only allows you to search towns, villages, cities, within the country your IP address is in currently. (can potentially test this with a VPN?)
Lat, Long search should still work, but untested.

Still need to have a searched location time conversion. As we still use the current machine time, not current time of the location. (the new API will help with this, as it does have an object property for current time at the location.)